### PR TITLE
make gooder with phi-3-128k-instruct

### DIFF
--- a/python/ctranslate2/converters/transformers.py
+++ b/python/ctranslate2/converters/transformers.py
@@ -1697,8 +1697,7 @@ class Phi3Loader(ModelLoader):
         rope_scaling = getattr(model.config, "rope_scaling", None)
         if rope_scaling:
             rotary_scaling_type = _SUPPORTED_ROPE_SCALING.get(rope_scaling["type"])
-            rotary_scaling_factor = rope_scaling["factor"]
-
+            rotary_scaling_factor = rope_scaling.get("factor", 1)  # Provide a default value of 1
             if rotary_scaling_type is None:
                 raise NotImplementedError(
                     "RoPE scaling type '%s' is not yet implemented. "


### PR DESCRIPTION
Wsup.  Here's my first attempt at modifying a converter.  Trying to get it to work with the phi3-instruct-128k model.  I ran ```converter.py``` in the main branch and it gave me this error, in relevant part:

<details><summary>ERROR</summary>
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\Scripts\benchmark_chat\Scripts\ct2-transformers-converter.exe\__main__.py", line 7, in <module>
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 2200, in main
    converter.convert_from_args(args)
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\converter.py", line 50, in convert_from_args
    return self.convert(
           ^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\converter.py", line 89, in convert
    model_spec = self._load()
                 ^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 141, in _load
    spec = loader(model, tokenizer)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 193, in __call__
    spec = self.get_model_spec(model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 1698, in get_model_spec
    rotary_scaling_factor = rope_scaling["factor"]
                            ~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'factor'
```
</details>

Chat-gpt said to modify it as set forth in this pull request, and now it's giving me a different error saying that ctranslate2 only supports "linear" role scaling and that it needs to use ```su``` whatever that is.

<details><summary>NEW ERROR</summary>

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\Scripts\benchmark_chat\Scripts\ct2-transformers-converter.exe\__main__.py", line 7, in <module>
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 2199, in main
    converter.convert_from_args(args)
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\converter.py", line 50, in convert_from_args
    return self.convert(
           ^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\converter.py", line 89, in convert
    model_spec = self._load()
                 ^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 141, in _load
    spec = loader(model, tokenizer)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 193, in __call__
    spec = self.get_model_spec(model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Scripts\benchmark_chat\Lib\site-packages\ctranslate2\converters\transformers.py", line 1700, in get_model_spec
    raise NotImplementedError(
NotImplementedError: RoPE scaling type 'su' is not yet implemented. The following RoPE scaling types are currently supported: linear
```
</details>

Since I don't even now what "rope" is let alone "linear" or "su," I've done this legwork and am now passing it off to you all as the experts.  Hope this helps.  Would be good to be able to use this model in general and bench it.

[EDIT]

Here's some additional legwork that I did, hope that it helps!

Claude Opus says to:

Steps to Add 'su' RoPE Scaling Type Support in CTranslate2

Update the _SUPPORTED_ROPE_SCALING dictionary:

Open the transformers.py file in the CTranslate2 converter.
Locate the _SUPPORTED_ROPE_SCALING dictionary.
Add an entry for the 'su' scaling type, mapping it to the corresponding attention_spec.RotaryScalingType enum value.


Modify the RotaryScalingType enum:

Open the attention_spec.py file.
Find the RotaryScalingType enum definition.
Add a new enum value for the 'su' scaling type.


## Here's what Claude Opus said after some minor questioning and feeding of scripts:

### Update the _SUPPORTED_ROPE_SCALING dictionary:
1. Open the `transformers.py` file in the CTranslate2 converter.
2. Locate the `_SUPPORTED_ROPE_SCALING` dictionary.
3. Add an entry for the 'su' scaling type, mapping it to the corresponding `attention_spec.RotaryScalingType` enum value.

### Modify the RotaryScalingType enum:
1. Open the `attention_spec.py` file.
2. Find the `RotaryScalingType` enum definition.
3. Add a new enum value for the 'su' scaling type.

### Update the CTranslate2 library's C++ code:
1. Open the `include/ctranslate2/layers/attention.h` file.
2. Locate the `RotaryScalingType` enum definition.
3. Add a new enum value for the 'su' scaling type.
4. Open the `src/layers/attention.cc` file.
5. Find the relevant functions that handle RoPE scaling (e.g., `dot_product_attention`).
6. Modify these functions to handle the 'su' scaling type correctly based on its mathematical formulation.
